### PR TITLE
Fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1080,7 +1080,7 @@ Please feel free to star ⭐ and share this repo if you find it a valuable resou
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Kedreamix/Awesome-Talking-Head-Synthesis&type=Date)](https://star-history.com/#Kedreamix/Awesome-Talking-Head-Synthesis&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Kedreamix/Awesome-Talking-Head-Synthesis&type=Date)](https://star-history.dera.page/#Kedreamix/Awesome-Talking-Head-Synthesis&Date)
 
 
 


### PR DESCRIPTION
The star history chart at the bottom of the README is currently broken because it relies on an API that is no longer working under GitHub stargazer restrictions. As a result, the chart fails to render for visitors.

This change points the chart to a working mirror so the project's star history displays correctly again.