### PR TITLE
为代码开源和论文中稿增加目录更新建议入口

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Open the catalog website / 打开论文目录网站
+    url: https://kedreamix.github.io/Awesome-Talking-Head-Synthesis/
+    about: Search the catalog before submitting a new paper or an update. / 提交新论文或更新前，请先在网站上搜索是否已收录。

--- a/.github/ISSUE_TEMPLATE/paper-suggestion.yml
+++ b/.github/ISSUE_TEMPLATE/paper-suggestion.yml
@@ -9,6 +9,10 @@ body:
 
         感谢你帮助完善论文目录。提交前，请先搜索网站和已有 Issue，确认论文尚未收录。
 
+        If the paper is already listed and you want to add code, an accepted venue, or another correction, please use the [Update a paper](https://github.com/Kedreamix/Awesome-Talking-Head-Synthesis/issues/new?template=paper-update.yml) form instead.
+
+        若论文已经收录，只是需要补充代码、中稿会议或其他勘误，请改用「更新论文信息」表单。
+
   - type: input
     id: title
     attributes:

--- a/.github/ISSUE_TEMPLATE/paper-update.yml
+++ b/.github/ISSUE_TEMPLATE/paper-update.yml
@@ -1,0 +1,92 @@
+name: Update a paper / 更新论文信息
+description: Report released code, an accepted venue, or catalog corrections / 反馈代码开源、论文中稿或目录勘误
+title: "[Update] "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form when a paper is already in the catalog, but its listing is out of date.
+
+        Typical updates:
+        - official code was released or the repository URL changed
+        - a preprint was accepted (venue / year should change)
+        - a project page, dataset, or other link should be added
+
+        请在论文**已经收录**、但条目需要更新时使用此表单。常见情况包括代码开源、预印本中稿、补充项目主页等。
+
+        If the paper is not listed yet, please use the [Suggest a paper](https://github.com/Kedreamix/Awesome-Talking-Head-Synthesis/issues/new?template=paper-suggestion.yml) form instead.
+
+        若论文尚未收录，请改用「推荐论文」表单。
+
+  - type: input
+    id: title
+    attributes:
+      label: Paper title / 论文标题
+      description: Use the title as it appears on the website. / 请填写网站上显示的论文标题。
+      placeholder: Full title of the listed paper / 已收录论文的完整标题
+    validations:
+      required: true
+
+  - type: input
+    id: paper
+    attributes:
+      label: Paper URL / 论文链接
+      description: arXiv, conference, or catalog link that identifies the existing entry. / 用于定位已有条目的 arXiv、会议或目录链接。
+      placeholder: https://arxiv.org/abs/...
+    validations:
+      required: true
+
+  - type: dropdown
+    id: update_type
+    attributes:
+      label: What changed? / 更新类型
+      description: Choose the closest option. You can add details below. / 请选择最接近的类型，细节可在下方补充。
+      options:
+        - Code released / 代码开源
+        - Code repository updated / 仓库地址更新
+        - Paper accepted / 论文中稿
+        - Project page added / 补充项目主页
+        - Venue or metadata correction / 会议或信息勘误
+        - Other / 其他
+    validations:
+      required: true
+
+  - type: input
+    id: code
+    attributes:
+      label: Code URL / 代码链接
+      description: Official implementation, or the updated repository URL. Leave blank if not applicable. / 官方实现或更新后的仓库地址；不适用可留空。
+      placeholder: https://github.com/owner/repository
+
+  - type: input
+    id: venue
+    attributes:
+      label: Accepted venue / 中稿会议或期刊
+      description: For example CVPR 2026, NeurIPS 2025, IEEE TPAMI. Leave blank if not a venue update. / 例如 CVPR 2026；若不是中稿更新可留空。
+      placeholder: CVPR 2026
+
+  - type: input
+    id: project
+    attributes:
+      label: Project page / 项目主页
+      description: Leave blank if unchanged. / 无变化可留空。
+      placeholder: https://example.github.io/project
+
+  - type: textarea
+    id: details
+    attributes:
+      label: What should we change? / 需要修改的内容
+      description: Briefly describe the update and any source we can verify. / 请简要说明应修改的内容，并尽量提供可核验来源。
+      placeholder: Official code was released at … / The paper was accepted at … / 官方代码已开源…… / 论文已被……接收
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Submission checks / 提交确认
+      options:
+        - label: This paper is already listed in the catalog. / 该论文已在目录中收录。
+          required: true
+        - label: I searched existing issues to avoid a duplicate update. / 我已搜索已有 Issue，避免重复提交。
+          required: true

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The paper list has grown large enough that browsing only in the README is no lon
 
 👉 [https://kedreamix.github.io/Awesome-Talking-Head-Synthesis/](https://kedreamix.github.io/Awesome-Talking-Head-Synthesis/)
 
-You can search papers, filter by category and year, switch between English / 中文, and use dark mode. If you find a missing paper or want to suggest a new category, please submit it through the website or GitHub Issues. 🙌
+You can search papers, filter by category and year, switch between English / 中文, and use dark mode. If you find a missing paper, newly released code, an accepted venue, or want to suggest a new category, please submit it through the website or GitHub Issues. 🙌
 
 ⭐ If the site helps you, please star the repo — it really motivates continued updates!
 

--- a/docs/app.js
+++ b/docs/app.js
@@ -12,6 +12,7 @@ const state = {
 };
 
 const REPO_API = "https://api.github.com/repos/Kedreamix/Awesome-Talking-Head-Synthesis";
+const ISSUE_NEW = "https://github.com/Kedreamix/Awesome-Talking-Head-Synthesis/issues/new";
 
 const TRANSLATIONS = {
   en: {
@@ -28,10 +29,11 @@ const TRANSLATIONS = {
     "stats.projects": "project pages",
     "stats.stars": "GitHub stars",
     "community.eyebrow": "Community curated",
-    "community.title": "Know a paper we missed?",
-    "community.description": "Recommend a new or missing paper through a short GitHub form. Include its title and link—we’ll review it for the next catalog update.",
+    "community.title": "Know something we missed?",
+    "community.description": "Recommend a missing paper, or tell us when a listed work released code or was accepted. A short GitHub form is enough—we’ll review it for the next catalog update.",
     "community.loading": "Catalog update date loading…",
     "community.suggest": "Suggest a paper",
+    "community.update": "Report an update",
     "community.view": "View existing suggestions",
     "areas.eyebrow": "Research areas",
     "areas.title": "Browse by category",
@@ -52,8 +54,11 @@ const TRANSLATIONS = {
     "links.code": "Code",
     "links.project": "Project",
     "links.data": "Data",
+    "links.update": "Update",
+    "links.updateHint": "Report new code, an accepted venue, or a correction",
     "empty.title": "No matching papers",
     "empty.description": "Try a broader search or clear the filters.",
+    "empty.suggest": "Suggest a missing paper",
     "theme.light": "Switch to light mode",
     "theme.dark": "Switch to dark mode",
     "stars.tracking": "Tracking starts today",
@@ -73,10 +78,11 @@ const TRANSLATIONS = {
     "stats.projects": "论文项目主页",
     "stats.stars": "GitHub 点赞",
     "community.eyebrow": "社区共同维护",
-    "community.title": "发现遗漏的论文？",
-    "community.description": "通过简短的 GitHub 表单推荐新论文或遗漏论文。提交标题和链接，我们会在下一次目录更新时审核。",
+    "community.title": "发现遗漏或有新进展？",
+    "community.description": "推荐尚未收录的论文，或反馈已收录工作新开源的代码、中稿会议。填写简短 GitHub 表单，我们会在下次更新时审核。",
     "community.loading": "正在读取目录更新时间…",
     "community.suggest": "推荐一篇论文",
+    "community.update": "反馈一条更新",
     "community.view": "查看已有推荐",
     "areas.eyebrow": "研究方向",
     "areas.title": "按类别浏览",
@@ -97,8 +103,11 @@ const TRANSLATIONS = {
     "links.code": "代码",
     "links.project": "主页",
     "links.data": "数据",
+    "links.update": "更新",
+    "links.updateHint": "反馈新代码、中稿会议或信息勘误",
     "empty.title": "没有匹配的论文",
     "empty.description": "请尝试更宽泛的关键词或清除筛选条件。",
+    "empty.suggest": "推荐一篇遗漏论文",
     "theme.light": "切换到浅色模式",
     "theme.dark": "切换到夜间模式",
     "stars.tracking": "今日开始记录",
@@ -224,6 +233,19 @@ function link(href, label, className) {
   return `<a class="${className}" href="${escapeHtml(href)}" target="_blank" rel="noopener noreferrer">${label}</a>`;
 }
 
+function issueUrl(template, title) {
+  const params = new URLSearchParams({
+    template,
+    title: String(title || "").slice(0, 240),
+  });
+  return `${ISSUE_NEW}?${params.toString()}`;
+}
+
+function updateLink(paper) {
+  const href = issueUrl("paper-update.yml", `[Update] ${paper.title}`);
+  return `<a class="chip chip--update" href="${escapeHtml(href)}" target="_blank" rel="noopener noreferrer" title="${escapeHtml(t("links.updateHint"))}">${t("links.update")}</a>`;
+}
+
 function matches(paper, filters) {
   if (filters.section && paper.section !== filters.section) return false;
   if (filters.year && String(paper.year) !== filters.year) return false;
@@ -293,6 +315,7 @@ function render() {
       link(paper.code, t("links.code"), "chip chip--code"),
       link(paper.project, t("links.project"), "chip chip--project"),
       link(paper.download, t("links.data"), "chip chip--download"),
+      updateLink(paper),
     ].filter(Boolean).join("");
 
     const title = paper.url

--- a/docs/index.html
+++ b/docs/index.html
@@ -95,19 +95,22 @@
     </div>
   </section>
 
-  <section class="community shell">
+  <section class="community shell" id="contribute">
     <div class="community__icon" aria-hidden="true">
       <svg viewBox="0 0 24 24"><path d="M12 3v18M3 12h18"/></svg>
     </div>
     <div class="community__copy">
       <p class="eyebrow"><span></span><b data-i18n="community.eyebrow">Community curated</b></p>
-      <h2 data-i18n="community.title">Know a paper we missed?</h2>
-      <p data-i18n="community.description">Recommend a new or missing paper through a short GitHub form. Include its title and link—we’ll review it for the next catalog update.</p>
+      <h2 data-i18n="community.title">Know something we missed?</h2>
+      <p data-i18n="community.description">Recommend a missing paper, or tell us when a listed work released code or was accepted. A short GitHub form is enough—we’ll review it for the next catalog update.</p>
       <small id="generated" data-i18n="community.loading">Catalog update date loading…</small>
     </div>
     <div class="community__actions">
       <a class="button button--accent button--large" href="https://github.com/Kedreamix/Awesome-Talking-Head-Synthesis/issues/new?template=paper-suggestion.yml" target="_blank" rel="noopener noreferrer">
         <span data-i18n="community.suggest">Suggest a paper</span><span aria-hidden="true">↗</span>
+      </a>
+      <a class="button button--ghost button--large" href="https://github.com/Kedreamix/Awesome-Talking-Head-Synthesis/issues/new?template=paper-update.yml" target="_blank" rel="noopener noreferrer">
+        <span data-i18n="community.update">Report an update</span><span aria-hidden="true">↗</span>
       </a>
       <a class="community__issues" href="https://github.com/Kedreamix/Awesome-Talking-Head-Synthesis/issues" target="_blank" rel="noopener noreferrer" data-i18n="community.view">View existing suggestions</a>
     </div>
@@ -179,6 +182,7 @@
     <div class="empty" id="empty" hidden>
       <strong data-i18n="empty.title">No matching papers</strong>
       <span data-i18n="empty.description">Try a broader search or clear the filters.</span>
+      <a class="empty__suggest" href="https://github.com/Kedreamix/Awesome-Talking-Head-Synthesis/issues/new?template=paper-suggestion.yml" target="_blank" rel="noopener noreferrer" data-i18n="empty.suggest">Suggest a missing paper</a>
     </div>
 
     <button class="load-more" id="load-more" type="button" hidden data-i18n="catalog.more">Show more papers</button>

--- a/docs/style.css
+++ b/docs/style.css
@@ -192,7 +192,16 @@ html[data-theme="dark"] .theme-toggle__moon { display: block; }
 .button svg { width: 17px; fill: currentColor; }
 .button--dark { color: white; background: var(--green); }
 .button--dark:hover { background: var(--green-2); }
-.button--accent { color: #211d18; background: var(--orange); }
+.button--accent { color: #211d18; background: var(--orange); border: 1px solid var(--orange); }
+.button--ghost {
+  color: #fff;
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, .32);
+}
+.button--ghost:hover {
+  background: rgba(255, 255, 255, .1);
+  border-color: rgba(255, 255, 255, .55);
+}
 .nav-star-count {
   min-width: 18px;
   padding-left: 8px;
@@ -509,8 +518,13 @@ h1 em {
   z-index: 1;
   display: flex;
   flex-direction: column;
-  align-items: center;
+  align-items: stretch;
   gap: 11px;
+  min-width: 228px;
+}
+
+.community__actions .button {
+  width: 100%;
 }
 
 .button--large {
@@ -521,6 +535,7 @@ h1 em {
 .community__issues {
   color: rgba(255, 255, 255, .62);
   font-size: 11px;
+  text-align: center;
   text-decoration: underline;
   text-underline-offset: 3px;
 }
@@ -841,6 +856,16 @@ h2 {
 .chip--code { color: var(--green-2); background: #eef6f1; }
 .chip--project { color: #365c7f; background: #f0f5fa; }
 .chip--download { color: #965332; background: #fdf1eb; }
+.chip--update {
+  color: var(--muted);
+  background: transparent;
+  border-style: dashed;
+}
+.chip--update:hover { color: var(--green-2); }
+
+html[data-theme="dark"] .chip--code { background: rgba(147, 216, 173, .12); }
+html[data-theme="dark"] .chip--project { background: rgba(150, 186, 216, .12); color: #9ec0dc; }
+html[data-theme="dark"] .chip--download { background: rgba(239, 124, 79, .12); color: #efb196; }
 
 .empty {
   padding: 80px 20px;
@@ -850,6 +875,15 @@ h2 {
 
 .empty strong { display: block; color: var(--ink); font: 500 26px Georgia, serif; }
 .empty span { display: block; margin-top: 8px; }
+.empty__suggest {
+  display: inline-flex;
+  margin-top: 18px;
+  color: var(--green-2);
+  font-size: 13px;
+  font-weight: 750;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
 
 .load-more {
   display: block;
@@ -873,7 +907,7 @@ h2 {
   .stat:nth-child(-n+2) { border-bottom: 1px solid var(--line); }
   .stat--stars { border-radius: 0 0 15px 0; }
   .community { grid-template-columns: 66px 1fr; }
-  .community__actions { grid-column: 2; align-items: flex-start; }
+  .community__actions { grid-column: 2; align-items: stretch; }
   .area-grid { grid-template-columns: repeat(3, 1fr); }
   .areas__heading { align-items: flex-start; }
   .filters { grid-template-columns: 1fr 1fr; }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 评估结论

**应该加，而且比「再多一个推荐论文按钮」更有价值。**

现有页面只有两类贡献入口：

- 推荐**尚未收录**的论文
- 建议新的研究分类

但这个目录真正会过时的地方，主要是**已经收录的条目**：

- 约 2/3 的论文还没有代码链接（937 篇中约 619 篇）
- 约 2/3 的 venue 仍写着 ArXiv（约 592 篇）

所以「仓库突然开源 / 预印本中稿」是社区最容易发现、维护者又最难全量盯住的更新。如果没有专门入口，大家要么不报，要么误用「推荐论文」表单，审核成本更高。

没有自建后端（站点是 GitHub Pages 静态站），继续走 GitHub Issue 表单是最合适的：零服务、可审核、和现有贡献流程一致。

## 这次做了什么

1. **新的 Issue 表单** `Update a paper / 更新论文信息`
   - 明确针对已收录论文
   - 覆盖：代码开源、仓库地址更新、论文中稿、项目主页、信息勘误
2. **社区区块增加第二条 CTA**：`Report an update` / `反馈一条更新`
3. **每篇论文卡片增加虚线 `Update` chip**
   - 浏览具体条目时就能提交
   - 会预填 `[Update] 论文标题`
4. 空结果页增加「推荐遗漏论文」入口；推荐论文表单会引导「已收录请改走更新表单」

## 刻意没做的

- 没有做站内自定义提交后端（静态站点不需要）
- 没有给每篇缺代码的论文再加一个醒目的 `Add code` 按钮，避免 600+ 条目看起来像半成品；用统一的 `Update` 承担这类贡献

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a06356-624f-71b4-992d-828895941900?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a06356-624f-71b4-992d-828895941900&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

